### PR TITLE
Make TFP logo responsive

### DIFF
--- a/scaffold/site_wrapper.html
+++ b/scaffold/site_wrapper.html
@@ -94,7 +94,7 @@
 
       <div class="blog-header" style="padding-bottom:30px;">
         <a href="[% mount_url %]/">
-          <img src="[% mount_url %]/img/TPF_news_header.png" style="height: 97px; width: 602px;" />
+          <img src="[% mount_url %]/img/TPF_news_header.png" style="height: 97px; width: 602px; max-width: 100%; height: auto;" />
         </a>
       </div>
 


### PR DESCRIPTION
Without this pages are either loaded not in responsive view (page is stretched), or logo is cut (also no ideal) -- _temporary fix until the new design is in place_.